### PR TITLE
ButtonSettings: Do not set backlight preferences when not asked for

### DIFF
--- a/src/com/android/settings/fragments/ButtonSettings.java
+++ b/src/com/android/settings/fragments/ButtonSettings.java
@@ -361,16 +361,10 @@ public class ButtonSettings extends SettingsPreferenceFragment implements
                 mShowNavbarPreference.setEnabled(false);
                 mHandler.postDelayed(resetNavbarToggle, 480);
             case KEY_HW_BUTTONS:
-                boolean newSetting = (key.equals(KEY_HW_BUTTONS)
-                    ? (boolean)objValue : !(boolean)objValue);
-                Settings.System.putIntForUser(getContentResolver(),
-                    Settings.System.BUTTON_BACKLIGHT_BRIGHTNESS,
-                    newSetting ? 1000 : 0, UserHandle.USER_CURRENT);
-                applyBacklightPrefPercentage(newSetting ? 1000 : 0);
                 if(mEnableHwButtonsPreference == null) break;
                 Settings.System.putIntForUser(getContentResolver(),
                     Settings.System.HARDWARE_BUTTONS_ENABLED,
-                        newSetting ? 1 : 0,
+                        ((boolean) objValue) ? 1 : 0,
                     UserHandle.USER_CURRENT);
                 break;
             case KEY_HW_BACKLIGHT:


### PR DESCRIPTION
* Fixes jank with the hw keys toggle where disabling and enabling
  clears user setting of button backlight delay and brightness and
  resets it to default.

Change-Id: I529413c20a8a17b4c13ffe2becd42b694d0d2393