### PR TITLE
Settings: Sim status and IMEI info are wrong if only sim2 inserted

### DIFF
--- a/src/com/android/settings/deviceinfo/imei/ImeiInfoDialogController.java
+++ b/src/com/android/settings/deviceinfo/imei/ImeiInfoDialogController.java
@@ -89,7 +89,8 @@ public class ImeiInfoDialogController {
 
     private void updateDialogForCdmaPhone() {
         final Resources res = mDialog.getContext().getResources();
-        mDialog.setText(ID_MEID_NUMBER_VALUE, getMeid());
+        mDialog.setText(ID_MEID_NUMBER_VALUE,
+                mSubscriptionInfo != null ? getMeid() : "");
         mDialog.setText(ID_MIN_NUMBER_VALUE,
                 mSubscriptionInfo != null ? mTelephonyManager.getCdmaMin(
                         mSubscriptionInfo.getSubscriptionId()) : "");
@@ -114,9 +115,13 @@ public class ImeiInfoDialogController {
     }
 
     private void updateDialogForGsmPhone() {
-        mDialog.setText(ID_IMEI_VALUE, getTextAsDigits(mTelephonyManager.getImei(mSlotId)));
+        mDialog.setText(ID_IMEI_VALUE,
+                mSubscriptionInfo != null ?
+                getTextAsDigits(mTelephonyManager.getImei(mSlotId)) : "");
         mDialog.setText(ID_IMEI_SV_VALUE,
-                getTextAsDigits(mTelephonyManager.getDeviceSoftwareVersion(mSlotId)));
+                mSubscriptionInfo != null ?
+                getTextAsDigits(mTelephonyManager.
+                        getDeviceSoftwareVersion(mSlotId)) : "");
         // device is not CDMA, do not display CDMA features
         mDialog.removeViewFromScreen(ID_CDMA_SETTINGS);
     }
@@ -127,11 +132,13 @@ public class ImeiInfoDialogController {
         if (subscriptionInfoList == null || subscriptionInfoList.size() <= slotId) {
             return null;
         }
-        try {
-            return subscriptionInfoList.get(slotId);
-        }catch(Exception e){
-            return null;
+
+        for (SubscriptionInfo info : subscriptionInfoList) {
+            if (slotId == info.getSimSlotIndex()) {
+                return info;
+            }
         }
+        return null;
     }
 
     @VisibleForTesting

--- a/src/com/android/settings/deviceinfo/simstatus/SimStatusDialogController.java
+++ b/src/com/android/settings/deviceinfo/simstatus/SimStatusDialogController.java
@@ -409,11 +409,15 @@ public class SimStatusDialogController implements LifecycleObserver, OnResume, O
     private SubscriptionInfo getPhoneSubscriptionInfo(int slotId) {
         final List<SubscriptionInfo> subscriptionInfoList = SubscriptionManager.from(
                 mContext).getActiveSubscriptionInfoList();
-        if (subscriptionInfoList != null && subscriptionInfoList.size() > slotId) {
-            return subscriptionInfoList.get(slotId);
-        } else {
+        if (subscriptionInfoList == null) {
             return null;
         }
+        for (SubscriptionInfo info : subscriptionInfoList) {
+            if (slotId == info.getSimSlotIndex()) {
+                return info;
+            }
+        }
+        return null;
     }
 
     @VisibleForTesting


### PR DESCRIPTION
Framework only returns the info of subscription which active
currently, not all the subscription info. so we must match the
slot position to find the right info from the list, otherwise
settings will FC if click IMEI2.

Change-Id: I00902e39b5dc9242a4fad686d2bdef464fea5d1c
CRs-Fixed: 2211867