### PR TITLE
Settings: Don't miss features when mobile network settings v2 is disa…

### DIFF
--- a/res/values/arrow_strings.xml
+++ b/res/values/arrow_strings.xml
@@ -78,6 +78,7 @@
 
     <!-- Network traffic -->
     <string name="traffic_title">Traffic indicators</string>
+    <string name="traffic_summary">Enable or disable network speed indicators</string>
     <string name="network_traffic_title">Network traffic</string>
     <string name="network_traffic_type">Select net activity type</string>
     <string name="show_network_traffic_up">Uplink</string>

--- a/res/xml/network_and_internet.xml
+++ b/res/xml/network_and_internet.xml
@@ -43,6 +43,14 @@
         settings:useAdminDisabledSummary="true">
     </com.android.settingslib.RestrictedPreference>
 
+    <Preference
+        android:key="traffic"
+        android:fragment="com.android.settings.arrow.Traffic"
+        android:order="-10"
+        android:icon="@drawable/ic_traffic"
+        android:title="@string/traffic_title"
+        android:summary="@string/traffic_summary" />
+
     <com.android.settingslib.RestrictedPreference
         android:fragment="com.android.settings.TetherSettings"
         android:key="tether_settings"
@@ -71,6 +79,12 @@
         settings:controller="com.android.settings.network.AirplaneModePreferenceController"
         settings:platform_slice="true"
         settings:userRestriction="no_airplane_mode"/>
+
+    <com.android.settings.arrow.preferences.SystemSettingSwitchPreference
+        android:key="roaming_indicator_icon"
+        android:title="@string/roaming_indicator_icon_title"
+        android:summary="@string/roaming_indicator_icon_summary"
+        android:defaultValue="true"/>
 
     <Preference
         android:fragment="com.android.settings.ProxySelector"

--- a/res/xml/network_and_internet_v2.xml
+++ b/res/xml/network_and_internet_v2.xml
@@ -56,7 +56,8 @@
         android:fragment="com.android.settings.arrow.Traffic"
         android:order="-10"
         android:icon="@drawable/ic_traffic"
-        android:title="@string/traffic_title" />
+        android:title="@string/traffic_title"
+        android:summary="@string/traffic_summary" />
 
     <com.android.settingslib.RestrictedSwitchPreference
         android:key="airplane_mode"


### PR DESCRIPTION
…bled

- Since QCom 10 telephony extension sets it to false,
  making those devices to use network_and_internet.xml
  meanwhile, network_and_internet_v2.xml is where we
  added our features to so show/add those to normal
  one too.

- Additionally a device can set :
  persist.sys.fflag.override.settings_network_and_internet_v2 to true
  to force enable settings_network_and_internet_v2.

- Note, settings_network_and_internet_v2 is true by default
  in AOSP

- Add a missing summary for traffic

Change-Id: I594991da38bddfe3aea077d50bfdec507f7ba4e4