### PR TITLE
Settings: Hide Dark theme styles ONLY when NIGHT MODE is disabled

### DIFF
--- a/res/values/arrow_strings.xml
+++ b/res/values/arrow_strings.xml
@@ -65,7 +65,7 @@
     <string name="security_settings_fingerprint_enroll_find_sensor_message_right" product="tablet">Locate the fingerprint sensor on the right side of your tablet.</string>
 
     <!-- Themes customisation -->
-    <string name="theme_customization_systemui_title">Color bucket</string>
+    <string name="theme_customization_systemui_title">Dark theme styles</string>
     <string name="theme_customization_accent_color_title">Accent color</string>
     <string name="theme_customization_font_title">Headline / Body font</string>
     <string name="theme_customization_icon_shape_title">Icon shape</string>

--- a/src/com/android/settings/display/CustomOverlayPreferenceController.java
+++ b/src/com/android/settings/display/CustomOverlayPreferenceController.java
@@ -102,9 +102,8 @@ public class CustomOverlayPreferenceController extends DeveloperOptionsPreferenc
         mCategory = category;
         mAvailable = overlayManager != null
                      && !getOverlayInfos().isEmpty()
-                     && mUiModeManager.getNightMode() == UiModeManager.MODE_NIGHT_YES;
+                     && mUiModeManager.getNightMode() != UiModeManager.MODE_NIGHT_NO;
     }
-
     public CustomOverlayPreferenceController(Context context, String category) {
         this(context, context.getPackageManager(), IOverlayManager.Stub
                 .asInterface(ServiceManager.getService(Context.OVERLAY_SERVICE)), category);
@@ -280,7 +279,7 @@ public class CustomOverlayPreferenceController extends DeveloperOptionsPreferenc
                 if (mUiModeManager.getNightMode() == UiModeManager.MODE_NIGHT_NO) {
 		    Log.w(TAG, "Dark mode turned off, unloading all custom overlays");
                     setOverlay(PACKAGE_DEVICE_DEFAULT);
-                } else if (mUiModeManager.getNightMode() == UiModeManager.MODE_NIGHT_YES) {
+                } else if (mUiModeManager.getNightMode() != UiModeManager.MODE_NIGHT_NO) {
                     // Set back previously selected overlay on re-enabling dark mode
                     setOverlay(Settings.System.getString(resolver, Settings.System.COLOR_BUCKET_OVERLAY));
                 }


### PR DESCRIPTION
- This way it shows up everytime but not when NIGHT_MODE is disabled
- Color Bucket -> Dark Theme Styles

test:
1. Keep Scheduled Dark Theme turned off,
enable OR disable Dark Theme and see
Dark Theme Styles is shown when enabled
And not shown when disabled

2. Enable Scheduled Dark theme, Dark Theme
Style Option is always shown letting you
select the style to be applied when it is
enabled afterwards.

Change-Id: Ic450d8e0a1d8bc97482290191d69b813681c5fc3